### PR TITLE
add '# encoding: utf-8' line in dylink.r2py

### DIFF
--- a/repyhelper.py
+++ b/repyhelper.py
@@ -44,7 +44,7 @@ WARNING_LABEL = """
 ### Deleting this file forces regeneration of a repy translation
 
 """
-
+# add 'coding: utf-8' to deal with ASCII characters problem
 ENCODING_STRING = """# -*- coding: utf-8 -*-"""
 
 class TranslationError(Exception):


### PR DESCRIPTION
this update deals with seattleinstaller fails on directories with non-ASCII characters issue.

See SeattleTestbed/dist#145.
